### PR TITLE
Handle existing PID file

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -153,6 +153,27 @@ if [ -n "${RLIMITS_RLIMIT_NPROC}" ]; then
   avahi_set "rlimits" "rlimit-nproc" "${RLIMITS_RLIMIT_NPROC}"
 fi
 
+# Cleanup PID if required (a PID is left but the process is no longer around)
+# This can happen if the container was killed
+PID_FILE=/var/run/avahi-daemon/pid
+if [ -f "${PID_FILE}" ]; then
+	AVAHI_PID="$(cat "${PID_FILE}")"
+	>&2 echo "Found PID file (${PID_FILE}) in container with PID ${AVAHI_PID}"
+	if [ "$$" == "${AVAHI_PID}" ]; then
+		>&2 echo "PID matches the current script"
+		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
+		>&2 rm -v "${PID_FILE}"
+	elif [ ! -d "/proc/${AVAHI_PID}" ]; then
+		>&2 echo "PID not found in current namespace"
+		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
+		>&2 rm -v "${PID_FILE}"
+	else
+		>&2 echo "PID is running, are you trying to start another instance?"
+		>&2 echo "Exiting without starting avahi"
+		exit 1
+	fi
+fi
+
 
 # Execute the provided command
 if [ $# == 0 ] || [ "${1:0:1}" == "-" ]; then


### PR DESCRIPTION
If there is an existing PID file when the entrypoint is run, make sure that there isn't another running instance at that PID and then delete the file. This file can be left after an ungraceful shutdown.

Resolves #7