### PR TITLE
Fix build workflow when triggered by PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build pull request
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v4
+        with:
+          context: src
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: false
+          tags: flungo/avahi:pull_request
       - name: Build and push
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v4
         with:
           context: src


### PR DESCRIPTION
The workflow when triggered by PR previously failed because the tag would be invalid. Avoid this issue by having a different step for PR builds.