### PR TITLE
Handle empty pid files

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -167,6 +167,9 @@ if [ -f "${PID_FILE}" ]; then
 		>&2 echo "PID not found in current namespace"
 		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
 		>&2 rm -v "${PID_FILE}"
+	elif [ -z "${AVAHI_PID}" ]; then
+		>&2 echo "PID file is empty, cleaning up"
+		>&2 rm -v "${PID_FILE}"
 	else
 		>&2 echo "PID is running, are you trying to start another instance?"
 		>&2 echo "Exiting without starting avahi"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -163,17 +163,14 @@ if [ -f "${PID_FILE}" ]; then
 		>&2 echo "PID matches the current script"
 		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
 		>&2 rm -v "${PID_FILE}"
-	elif [ ! -d "/proc/${AVAHI_PID}" ]; then
-		>&2 echo "PID not found in current namespace"
-		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
-		>&2 rm -v "${PID_FILE}"
-	elif [ -z "${AVAHI_PID}" ]; then
-		>&2 echo "PID file is empty, cleaning up"
-		>&2 rm -v "${PID_FILE}"
-	else
+	elif [ -d "/proc/${AVAHI_PID}" ]; then
 		>&2 echo "PID is running, are you trying to start another instance?"
 		>&2 echo "Exiting without starting avahi"
 		exit 1
+	else
+		>&2 echo "PID not found in current namespace or invalid"
+		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
+		>&2 rm -v "${PID_FILE}"
 	fi
 fi
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -159,18 +159,21 @@ PID_FILE=/var/run/avahi-daemon/pid
 if [ -f "${PID_FILE}" ]; then
 	AVAHI_PID="$(cat "${PID_FILE}")"
 	>&2 echo "Found PID file (${PID_FILE}) in container with PID ${AVAHI_PID}"
-	if [ "$$" == "${AVAHI_PID}" ]; then
+  if [ -z "${AVAHI_PID}" ]; then
+		>&2 echo "PID file is empty, cleaning up"
+		>&2 rm -v "${PID_FILE}"
+	elif [ "$$" == "${AVAHI_PID}" ]; then
 		>&2 echo "PID matches the current script"
 		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
 		>&2 rm -v "${PID_FILE}"
-	elif [ -d "/proc/${AVAHI_PID}" ]; then
+	elif [ ! -d "/proc/${AVAHI_PID}" ]; then
+		>&2 echo "PID not found in current namespace"
+		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
+		>&2 rm -v "${PID_FILE}"
+	else
 		>&2 echo "PID is running, are you trying to start another instance?"
 		>&2 echo "Exiting without starting avahi"
 		exit 1
-	else
-		>&2 echo "PID not found in current namespace or invalid"
-		>&2 echo "Safe to assume a previous instance of avahi exited uncleanly"
-		>&2 rm -v "${PID_FILE}"
 	fi
 fi
 


### PR DESCRIPTION
We had an issue with an empty PID file:

```
Found PID file (/var/run/avahi-daemon/pid) in container with PID 
PID is running, are you trying to start another instance?
Exiting without starting avahi
```