### PR TITLE
Update GitHub Actions workflow and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,33 +7,31 @@ on:
   push:
     branches:
       - 'main'
-      - 'dev'
     tags:
       - 'v*.*.*'
   pull_request:
     branches:
       - 'main'
-      - 'dev'
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build pull request
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: src
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -41,7 +39,7 @@ jobs:
           tags: flungo/avahi:pull_request
       - name: Build and push
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: src
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -49,7 +47,7 @@ jobs:
           tags: flungo/avahi:${{ github.ref_name }}
       - name: Build and push latest
         if: github.ref_name == 'main'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: src
           platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
## Summary
This PR updates the CI/CD workflow to use the latest versions of GitHub Actions and removes the `dev` branch from the workflow triggers. Additionally, Dependabot configuration is added to automatically keep GitHub Actions dependencies up to date.

## Key Changes
- **Removed `dev` branch** from push and pull request triggers in the workflow
- **Updated GitHub Actions to latest versions:**
  - `actions/checkout@v3` → `v4`
  - `docker/setup-qemu-action@v2` → `v3`
  - `docker/setup-buildx-action@v2` → `v3`
  - `docker/login-action@v2` → `v3`
  - `docker/build-push-action@v4` → `v6`
- **Added Dependabot configuration** to automatically check for updates to GitHub Actions on a weekly schedule

## Implementation Details
The workflow now focuses on the `main` branch and version tags only, simplifying the CI/CD pipeline. The Dependabot configuration will help keep GitHub Actions dependencies current with minimal manual intervention.

https://claude.ai/code/session_01EZ5g73mHD6zFsUuvJtMCdw